### PR TITLE
chore: add min-release-age=7 to .npmrc for supply chain security

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7


### PR DESCRIPTION
Adds `min-release-age=7` to `.npmrc` to improve supply chain security by requiring npm packages to be at least 7 days old before installation.